### PR TITLE
✨ Feat: /searchページでdebounce処理を用いてサジェスト機能を実装

### DIFF
--- a/app/components/global/menu.tsx
+++ b/app/components/global/menu.tsx
@@ -16,7 +16,7 @@ const Menu = () => {
 					<li className="flex-1">
 						<NavLink to="/search" className={linkClass} aria-label="検索">
 							<Search className="w-8 h-8" />
-							<p className="text-xs">検索</p>
+							<p className="text-xs">検索/作成</p>
 						</NavLink>
 					</li>
 					<li className="flex-1">

--- a/app/components/global/menu.tsx
+++ b/app/components/global/menu.tsx
@@ -14,7 +14,7 @@ const Menu = () => {
 			<nav className="mx-auto" aria-label="メインナビゲーション">
 				<ul className="flex">
 					<li className="flex-1">
-						<NavLink to="/search" className={linkClass} aria-label="検索">
+						<NavLink to="/search" className={linkClass} aria-label="検索/作成">
 							<Search className="w-8 h-8" />
 							<p className="text-xs">検索/作成</p>
 						</NavLink>

--- a/app/components/ui/command.tsx
+++ b/app/components/ui/command.tsx
@@ -19,35 +19,66 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-const CommandInput = React.forwardRef<
-	React.ElementRef<typeof CommandPrimitive.Input>,
-	React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => {
-	const [inputValue, setInputValue] = React.useState<string>("");
+interface CommandInputProps extends React.ComponentProps<"input"> {
+	icon?: React.ReactNode;
+	search?: boolean;
+	handleSearch?: () => void;
+}
 
-	return (
-		<div
-			className="flex items-center border-b px-3 relative"
-			cmdk-input-wrapper=""
-		>
-			<Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
-			<CommandPrimitive.Input
-				ref={ref}
+const CommandInput = React.forwardRef<HTMLInputElement, CommandInputProps>(
+	(
+		{
+			className,
+			type = "text",
+			icon = <Search className="h-4 w-4" />,
+			search,
+			handleSearch,
+			...props
+		},
+		ref,
+	) => {
+		const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+			if (event.key === "Enter" && handleSearch) {
+				handleSearch(); // Enterキーが押されたときに検索を実行
+			}
+		};
+
+		return (
+			<div
 				className={cn(
-					"flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+					"relative flex items-center border px-3 rounded-md bg-transparent",
+					search,
 					className,
 				)}
-				onInput={(e) => setInputValue(e.currentTarget.value)}
-				{...props}
-			/>
-			{inputValue && (
-				<Badge className="absolute right-3 top-3 animate-fade">
-					Enter or click
-				</Badge>
-			)}
-		</div>
-	);
-});
+			>
+				{icon && (
+					<div className="absolute left-3 flex items-center justify-center">
+						{icon}
+					</div>
+				)}
+				<input
+					type={type}
+					className={cn(
+						"w-full h-12 pl-6 pr-4 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+						className,
+					)}
+					ref={ref}
+					onKeyDown={handleKeyDown}
+					{...props}
+				/>
+				{search && props.value && (
+					<Badge
+						className="absolute right-3 top-1/2 transform -translate-y-1/2 cursor-pointer"
+						onClick={handleSearch}
+					>
+						<span className="sm:hidden">clickで検索</span>
+						<span className="hidden sm:inline">Enter or clickで検索</span>
+					</Badge>
+				)}
+			</div>
+		);
+	},
+);
 
 const CommandList = React.forwardRef<
 	React.ElementRef<typeof CommandPrimitive.List>,

--- a/app/components/ui/command.tsx
+++ b/app/components/ui/command.tsx
@@ -58,6 +58,8 @@ const CommandInput = React.forwardRef<HTMLInputElement, CommandInputProps>(
 				)}
 				<input
 					type={type}
+					role="searchbox"
+					aria-label="検索"
 					className={cn(
 						"w-full h-12 pl-6 pr-4 bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
 						className,

--- a/app/routes/api.datamuse.tsx
+++ b/app/routes/api.datamuse.tsx
@@ -1,0 +1,22 @@
+import { json } from "@remix-run/node";
+
+export const loader = async ({ request }: { request: Request }) => {
+	const url = new URL(request.url);
+	const query = url.searchParams.get("query");
+
+	if (!query) {
+		return json({ suggestions: [] }, { status: 400 });
+	}
+
+	const response = await fetch(
+		`https://api.datamuse.com/words?sp=${encodeURIComponent(query)}*&max=10`,
+	);
+
+	if (!response.ok) {
+		return json({ suggestions: [] }, { status: response.status });
+	}
+
+	const data = await response.json();
+
+	return json({ suggestions: data });
+};

--- a/app/routes/api.datamuse.tsx
+++ b/app/routes/api.datamuse.tsx
@@ -1,5 +1,10 @@
 import { json } from "@remix-run/node";
 
+interface DatamuseResponse {
+	word: string;
+	score: number;
+}
+
 export const loader = async ({ request }: { request: Request }) => {
 	const url = new URL(request.url);
 	const query = url.searchParams.get("query");
@@ -10,13 +15,16 @@ export const loader = async ({ request }: { request: Request }) => {
 
 	const response = await fetch(
 		`https://api.datamuse.com/words?sp=${encodeURIComponent(query)}*&max=10`,
+		{
+			signal: AbortSignal.timeout(5000),
+		},
 	);
 
 	if (!response.ok) {
 		return json({ suggestions: [] }, { status: response.status });
 	}
 
-	const data = await response.json();
+	const data: DatamuseResponse[] = await response.json();
 
 	return json({ suggestions: data });
 };

--- a/app/routes/search/SuggestInput.tsx
+++ b/app/routes/search/SuggestInput.tsx
@@ -1,0 +1,69 @@
+import { useFetcher } from "@remix-run/react";
+import { ArrowRight } from "lucide-react";
+import { useState } from "react";
+
+import {
+	Command,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "~/components/ui/command";
+import { useDebounce } from "./useDebounce";
+
+interface Suggestion {
+	word: string;
+}
+
+interface FetcherData {
+	suggestions: Suggestion[];
+}
+
+const SuggestInput = () => {
+	const [inputValue, setInputValue] = useState("");
+	const fetcher = useFetcher<FetcherData>();
+	const debouncedFetch = useDebounce(600);
+
+	const handleInputChange = (value: string) => {
+		setInputValue(value);
+		debouncedFetch(() => {
+			if (value.trim()) {
+				fetcher.load(`/api/datamuse?query=${encodeURIComponent(value)}`);
+			}
+		});
+	};
+
+	const suggestions: Suggestion[] = fetcher.data?.suggestions || [];
+	const isLoading = fetcher.state === "loading";
+
+	return (
+		<Command className="rounded-lg border shadow-md md:min-w-[450px]">
+			<CommandInput
+				placeholder="英単語を入力してください"
+				value={inputValue}
+				onChange={(e) => handleInputChange(e.target.value)} // 入力値を更新
+				search
+			/>
+			{inputValue.trim() && (
+				<CommandList>
+					<CommandGroup heading="サジェストワード">
+						{isLoading ? (
+							<div className="flex justify-center py-4" aria-label="読み込み中">
+								<div className="animate-spin h-5 w-5 border-2 border-gray-400 rounded-full border-t-transparent" />
+							</div>
+						) : (
+							suggestions.map((suggestion) => (
+								<CommandItem key={suggestion.word}>
+									<ArrowRight />
+									<span>{suggestion.word}</span>
+								</CommandItem>
+							))
+						)}
+					</CommandGroup>
+				</CommandList>
+			)}
+		</Command>
+	);
+};
+
+export default SuggestInput;

--- a/app/routes/search/SuggestInput.tsx
+++ b/app/routes/search/SuggestInput.tsx
@@ -28,7 +28,11 @@ const SuggestInput = () => {
 		setInputValue(value);
 		debouncedFetch(() => {
 			if (value.trim()) {
-				fetcher.load(`/api/datamuse?query=${encodeURIComponent(value)}`);
+				try {
+					fetcher.load(`/api/datamuse?query=${encodeURIComponent(value)}`);
+				} catch (_err) {
+					Error("検索中にエラーが発生しました。");
+				}
 			}
 		});
 	};
@@ -37,16 +41,20 @@ const SuggestInput = () => {
 	const isLoading = fetcher.state === "loading";
 
 	return (
-		<Command className="rounded-lg border shadow-md md:min-w-[450px]">
+		<Command
+			className="rounded-lg border shadow-md md:min-w-[450px]"
+			aria-label="単語検索"
+		>
 			<CommandInput
 				placeholder="英単語を入力してください"
 				value={inputValue}
-				onChange={(e) => handleInputChange(e.target.value)} // 入力値を更新
+				onChange={(e) => handleInputChange(e.target.value)}
+				aria-label="検索キーワード"
 				search
 			/>
 			{inputValue.trim() && (
 				<CommandList>
-					<CommandGroup heading="サジェストワード">
+					<CommandGroup heading="サジェストワード" aria-live="polite">
 						{isLoading ? (
 							<div className="flex justify-center py-4" aria-label="読み込み中">
 								<div className="animate-spin h-5 w-5 border-2 border-gray-400 rounded-full border-t-transparent" />

--- a/app/routes/search/index.tsx
+++ b/app/routes/search/index.tsx
@@ -1,64 +1,10 @@
-import { ArrowRight } from "lucide-react";
-
-import {
-	Command,
-	CommandGroup,
-	CommandInput,
-	CommandItem,
-	CommandList,
-} from "~/components/ui/command";
+import SuggestInput from "./SuggestInput";
 
 const SearchPage = () => {
 	return (
 		<div className="h-screen">
 			<div className="mt-10">
-				<Command className="rounded-lg border shadow-md md:min-w-[450px]">
-					<CommandInput placeholder="英単語を入力してください" />
-					<CommandList>
-						<CommandGroup heading="サジェストワード">
-							<CommandItem>
-								<ArrowRight />
-								<span>anything else</span>
-							</CommandItem>
-							<CommandItem>
-								<ArrowRight />
-								<span>anything goes</span>
-							</CommandItem>
-							<CommandItem>
-								<ArrowRight />
-								<span>anything new</span>
-							</CommandItem>
-							<CommandItem>
-								<ArrowRight />
-								<span>anything wrong</span>
-							</CommandItem>
-							<CommandItem>
-								<ArrowRight />
-								<span>anything interesting</span>
-							</CommandItem>
-							<CommandItem>
-								<ArrowRight />
-								<span>anything special</span>
-							</CommandItem>
-							<CommandItem>
-								<ArrowRight />
-								<span>anything specific</span>
-							</CommandItem>
-							<CommandItem>
-								<ArrowRight />
-								<span>anything unusual</span>
-							</CommandItem>
-							<CommandItem>
-								<ArrowRight />
-								<span>anything important</span>
-							</CommandItem>
-							<CommandItem>
-								<ArrowRight />
-								<span>anything available</span>
-							</CommandItem>
-						</CommandGroup>
-					</CommandList>
-				</Command>
+				<SuggestInput />
 			</div>
 		</div>
 	);

--- a/app/routes/search/useDebounce.ts
+++ b/app/routes/search/useDebounce.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 export const useDebounce = (timeout: number) => {
 	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -14,6 +14,14 @@ export const useDebounce = (timeout: number) => {
 		},
 		[timeout],
 	);
+
+	useEffect(() => {
+		return () => {
+			if (timer.current) {
+				clearTimeout(timer.current);
+			}
+		};
+	}, []);
 
 	return debouncedFetch;
 };

--- a/app/routes/search/useDebounce.ts
+++ b/app/routes/search/useDebounce.ts
@@ -1,0 +1,19 @@
+import { useCallback, useRef } from "react";
+
+export const useDebounce = (timeout: number) => {
+	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const debouncedFetch = useCallback(
+		(callback: () => void) => {
+			if (timer.current) {
+				clearTimeout(timer.current);
+			}
+			timer.current = setTimeout(() => {
+				callback();
+			}, timeout);
+		},
+		[timeout],
+	);
+
+	return debouncedFetch;
+};


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
title通り。

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1]debounceのカスタムフックを作成
- [変更点2]datamuse APIからサジェストワードを獲得

## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [x] サジェストが機能していることを確認。
- [x] decounceが機能しているか？

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->
#11 #2 

## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->
- [debounceカスタムフック](https://zenn.dev/counterworks/articles/debounce-real-time-search)
- [Datamuse API](https://www.datamuse.com/api/)

## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->

[![Image from Gyazo](https://i.gyazo.com/848a385b3f056c06aa84c660ee7495a8.png)](https://gyazo.com/848a385b3f056c06aa84c660ee7495a8)

## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->
気づいたことがあり、/api/datamuseも/api/unsplashもリクエストするごとに画面全体に再レンダリングするということだ。独自で調査したが、おそらくだが、loaderが悪さしているのではないかと思った。というかloaderってページ初期のデータを引っ張ってくるものであって、apiに取得するものではない気がする。(だから画面全体にレンダリングが走る？)

サーバー側でリクエストできるという理由で使っていたが、別の手段Honoを試してみるのもいいかもしれない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- メニューコンポーネントの検索リンクのテキストを「検索」から「検索/作成」に変更。
	- 新しいコンポーネント「SuggestInput」を追加し、APIからの提案を表示。
	- デバウンス機能を持つカスタムフック「useDebounce」を追加。

- **バグ修正**
	- なし

- **ドキュメント**
	- なし

- **リファクタリング**
	- `CommandInput` コンポーネントを改良し、アイコンと検索バッジを追加。
	- `SearchPage` コンポーネントを `SuggestInput` に置き換え、構造を簡素化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->