### PR TITLE
🎨 Style: /cards画面でFilter中にDragできなくする

### DIFF
--- a/app/routes/cards/FilterInput.tsx
+++ b/app/routes/cards/FilterInput.tsx
@@ -15,7 +15,7 @@ const FilterInput = ({ words, children }: FilterInputProps) => {
 	return (
 		<div className="mt-10">
 			<Input
-				placeholder="英単語を絞り込めます"
+				placeholder="英単語で絞り込めます"
 				icon={<Filter className="h-4 w-4 text-gray-400" />}
 				onChange={(e) => setFilterText(e.target.value)}
 			/>

--- a/app/routes/cards/WordCard.tsx
+++ b/app/routes/cards/WordCard.tsx
@@ -10,9 +10,10 @@ interface WordCardProps {
 	word: UniqueIdentifier;
 	style?: React.CSSProperties;
 	isOverlay?: boolean;
+	filterText?: string;
 }
 
-const WordCard = ({ word, style, isOverlay }: WordCardProps) => {
+const WordCard = ({ word, style, isOverlay, filterText }: WordCardProps) => {
 	const {
 		attributes,
 		listeners,
@@ -24,12 +25,10 @@ const WordCard = ({ word, style, isOverlay }: WordCardProps) => {
 		id: word,
 	});
 
-	// エラーハンドリング
 	if (typeof word !== "string") {
 		return null;
 	}
 
-	// isDraggingの時は`hr`のデザインをレンダリング
 	if (isDragging) {
 		return (
 			<div
@@ -46,7 +45,6 @@ const WordCard = ({ word, style, isOverlay }: WordCardProps) => {
 		);
 	}
 
-	// isOverlayの時は通常カードを背景色変更してレンダリング
 	if (isOverlay) {
 		return (
 			<Card
@@ -73,7 +71,6 @@ const WordCard = ({ word, style, isOverlay }: WordCardProps) => {
 		);
 	}
 
-	// 通常状態のデザインをレンダリング
 	return (
 		<Card
 			ref={setNodeRef}
@@ -107,14 +104,16 @@ const WordCard = ({ word, style, isOverlay }: WordCardProps) => {
 							}
 						/>
 					</div>
-					<div
-						className="cursor-grab flex-shrink-0 touch-none"
-						{...listeners}
-						{...attributes}
-						aria-label="ドラッグハンドル"
-					>
-						<GripVertical className="h-7 w-7 text-gray-400 hover:text-gray-500" />
-					</div>
+					{!filterText && (
+						<div
+							className="cursor-grab flex-shrink-0 touch-none"
+							{...listeners}
+							{...attributes}
+							aria-label="ドラッグハンドル"
+						>
+							<GripVertical className="h-7 w-7 text-gray-400 hover:text-gray-500" />
+						</div>
+					)}
 				</div>
 			</div>
 		</Card>

--- a/app/routes/cards/WordList.tsx
+++ b/app/routes/cards/WordList.tsx
@@ -27,10 +27,10 @@ const WordList = ({ words, filterText }: WordListProps) => {
 	return (
 		<>
 			{filteredWords.length > 0 ? (
-				<ScrollArea className="sm:h-[78vh] min-h-[30vh] w-full sm:w-2/3 rounded-md sm:border overflow-hidden">
+				<ScrollArea className="sm:h-[78vh] min-h-[75vh] w-full sm:w-2/3 rounded-md sm:border overflow-hidden">
 					<div className="sm:m-4 space-y-2">
 						{filteredWords.map((word) => (
-							<WordCard key={word} word={word} />
+							<WordCard key={word} word={word} filterText={filterText} />
 						))}
 					</div>
 				</ScrollArea>

--- a/app/routes/slide/index.tsx
+++ b/app/routes/slide/index.tsx
@@ -2,7 +2,7 @@ import WordsSlide from "./WordsSlide";
 
 const SlidePage = () => {
 	return (
-		<div className="my-4 min-h-[85vh]">
+		<div className="my-4 min-h-[95vh]">
 			<WordsSlide />
 			<p
 				className="mt-4 text-center text-gray-400 hover:underline hover:text-gray-500 cursor-pointer"


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
Filter中にDrag操作を許してしまうとpositionレコードの値の調整が大変になるので禁止にした。

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1] /cardsのスマホサイズの最小高さを変更
- [変更点2]/cardsのフィルタリング時にDragアイコンを表示しない
- [変更点3]/slideの最小高さを変更

## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [ ] filter時にDragアイコンが表示されていないか

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->
#2 

## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->


## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->

[![Image from Gyazo](https://i.gyazo.com/60af967b6da2427df3879855eba9a963.png)](https://gyazo.com/60af967b6da2427df3879855eba9a963)

## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `WordCard`コンポーネントに新しいオプショナルプロパティ`filterText`を追加。
  - `WordList`コンポーネントで`ScrollArea`の最小高さを`30vh`から`75vh`に増加。

- **変更点**
  - `FilterInput`コンポーネントのプレースホルダーを更新。
  - `SlidePage`コンポーネントの最小高さを`85vh`から`95vh`に増加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->