### PR TITLE
🧹 Refactor: wordをpropsで渡して削除時に表示されるように

### DIFF
--- a/app/features/cards/word/components/EditHeader.tsx
+++ b/app/features/cards/word/components/EditHeader.tsx
@@ -7,9 +7,10 @@ import type { Tag } from "~/types/word";
 
 interface EditHeaderProps {
 	tags: Tag[];
+	word: string;
 }
 
-const EditHeader = ({ tags }: EditHeaderProps) => {
+const EditHeader = ({ tags, word }: EditHeaderProps) => {
 	const navigate = useNavigate();
 
 	return (
@@ -37,7 +38,7 @@ const EditHeader = ({ tags }: EditHeaderProps) => {
 					}
 				/>
 				<DeleteModal
-					word="word"
+					word={word}
 					triggerElement={
 						<Button
 							type="button"

--- a/app/features/cards/word/components/WordForm.tsx
+++ b/app/features/cards/word/components/WordForm.tsx
@@ -126,7 +126,7 @@ const WordForm = ({ wordDetail }: { wordDetail: WordDetail }) => {
 		<>
 			<Form {...form}>
 				<form onSubmit={form.handleSubmit(onSubmit)}>
-					<EditHeader tags={wordDetail.tags || []} />
+					<EditHeader tags={wordDetail.tags || []} word={wordDetail.word} />
 					<div className="mt-3 space-y-3">
 						<FormField
 							name="word"


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
タイトル通り

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1]DeleteModalに削除されるwordが確認とれるようになった。

## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [ ]DeleteModalに削除されるwordが確認とれるようになった。

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->

## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->

## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->

## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - カード編集画面のヘッダーが、静的な文字列から動的な単語情報を反映するようになりました。これにより、操作中のカード内容に応じた柔軟な表示が実現され、確認ダイアログなどでも最新の単語情報を正確に利用できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->