### PR TITLE
🐞  Fix: WordForm内のvalidationをpropsに最大文字数を流して、変更できるように

### DIFF
--- a/app/features/cards/word/components/TextPairManager.tsx
+++ b/app/features/cards/word/components/TextPairManager.tsx
@@ -5,30 +5,20 @@ import { z } from "zod";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 
-// 🔥 バリデーションスキーマ
-const textPairSchema = z.object({
-	items: z
-		.array(
-			z.object({
-				id: z.number(),
-				text: z
-					.string()
-					.nonempty({ message: "英文を入力してください" })
-					.max(200, { message: "英文は200文字以内で入力してください" }),
-				translation: z
-					.string()
-					.nonempty({ message: "翻訳を入力してください" })
-					.max(300, { message: "翻訳は300文字以内で入力してください" }),
-			}),
-		)
-		.max(5, { message: "最大5件まで入力できます" }),
-});
-
-type TextPairFormData = z.infer<typeof textPairSchema>;
+// 🔥 型の定義
+type TextPairFormData = {
+	items: {
+		id: number;
+		text: string;
+		translation: string;
+	}[];
+};
 
 interface TextPairManagerProps {
 	type: "synonyms" | "antonyms" | "collocations" | "examples";
 	initialData: { id: number; text: string; translation: string }[];
+	maxTextLength: number;
+	maxTranslationLength: number;
 }
 
 const TYPE_LABELS = {
@@ -38,7 +28,34 @@ const TYPE_LABELS = {
 	examples: "例文",
 };
 
-const TextPairManager = ({ type, initialData }: TextPairManagerProps) => {
+const TextPairManager = ({
+	type,
+	initialData,
+	maxTextLength,
+	maxTranslationLength,
+}: TextPairManagerProps) => {
+	const textPairSchema = z.object({
+		items: z
+			.array(
+				z.object({
+					id: z.number(),
+					text: z
+						.string()
+						.nonempty({ message: "英文を入力してください" })
+						.max(maxTextLength, {
+							message: `英文は${maxTextLength}文字以内で入力してください`,
+						}),
+					translation: z
+						.string()
+						.nonempty({ message: "翻訳を入力してください" })
+						.max(maxTranslationLength, {
+							message: `翻訳は${maxTranslationLength}文字以内で入力してください`,
+						}),
+				}),
+			)
+			.max(5, { message: "最大5件まで入力できます" }),
+	});
+
 	const {
 		control,
 		handleSubmit,
@@ -54,14 +71,12 @@ const TextPairManager = ({ type, initialData }: TextPairManagerProps) => {
 		name: "items",
 	});
 
-	// 🔥 データ追加
 	const handleAdd = () => {
 		if (fields.length < 5) {
 			append({ id: Date.now(), text: "", translation: "" });
 		}
 	};
 
-	// 🔥 送信（仮）
 	const onSubmit = (data: TextPairFormData) => {
 		console.log(`${TYPE_LABELS[type]} を保存:`, data.items);
 	};

--- a/app/features/cards/word/components/WordForm.tsx
+++ b/app/features/cards/word/components/WordForm.tsx
@@ -36,62 +36,6 @@ const formSchema = z.object({
 			message: "意味は300文字以内で入力してください",
 		})
 		.optional(),
-	synonyms: z
-		.array(
-			z.object({
-				id: z.number(),
-				text: z.string().max(50, {
-					message: "英文は50文字以内で入力してください",
-				}),
-				translation: z.string().max(200, {
-					message: "翻訳は200文字以内で入力してください",
-				}),
-			}),
-		)
-		.max(5, { message: "類義語は最大5件まで入力できます" })
-		.optional(),
-	antonyms: z
-		.array(
-			z.object({
-				id: z.number(),
-				text: z.string().max(50, {
-					message: "英文は50文字以内で入力してください",
-				}),
-				translation: z.string().max(100, {
-					message: "翻訳は100文字以内で入力してください",
-				}),
-			}),
-		)
-		.max(5, { message: "対義語は最大5件まで入力できます" })
-		.optional(),
-	collocations: z
-		.array(
-			z.object({
-				id: z.number(),
-				text: z.string().max(100, {
-					message: "英文は100文字以内で入力してください",
-				}),
-				translation: z.string().max(200, {
-					message: "翻訳は200文字以内で入力してください",
-				}),
-			}),
-		)
-		.max(5, { message: "コロケーションは最大5件まで入力できます" })
-		.optional(),
-	examples: z
-		.array(
-			z.object({
-				id: z.number(),
-				text: z.string().max(200, {
-					message: "英文は200文字以内で入力してください",
-				}),
-				translation: z.string().max(300, {
-					message: "翻訳は300文字以内で入力してください",
-				}),
-			}),
-		)
-		.max(5, { message: "例文は最大5件まで入力できます" })
-		.optional(),
 	other: z
 		.string()
 		.max(500, {
@@ -110,10 +54,6 @@ const WordForm = ({ wordDetail }: { wordDetail: WordDetail }) => {
 			translation: wordDetail.translation || "",
 			pronunciation: wordDetail.pronunciation || "",
 			meaning: wordDetail.meaning || "",
-			synonyms: wordDetail.synonyms || [],
-			antonyms: wordDetail.antonyms || [],
-			collocations: wordDetail.collocations || [],
-			examples: wordDetail.examples || [],
 			other: wordDetail.other || "",
 		},
 	});
@@ -183,25 +123,34 @@ const WordForm = ({ wordDetail }: { wordDetail: WordDetail }) => {
 								</FormItem>
 							)}
 						/>
+
 						<div>
 							<Label className="mb-2">類義語</Label>
 							<TextPairManager
 								type="synonyms"
 								initialData={wordDetail.synonyms || []}
+								maxTextLength={50}
+								maxTranslationLength={1000}
 							/>
 						</div>
+
 						<div>
 							<Label className="mb-2">対義語</Label>
 							<TextPairManager
 								type="antonyms"
 								initialData={wordDetail.antonyms || []}
+								maxTextLength={50}
+								maxTranslationLength={100}
 							/>
 						</div>
+
 						<div>
 							<Label className="mb-2">コロケーション</Label>
 							<TextPairManager
 								type="collocations"
 								initialData={wordDetail.collocations || []}
+								maxTextLength={100}
+								maxTranslationLength={200}
 							/>
 						</div>
 
@@ -210,6 +159,8 @@ const WordForm = ({ wordDetail }: { wordDetail: WordDetail }) => {
 							<TextPairManager
 								type="examples"
 								initialData={wordDetail.examples || []}
+								maxTextLength={100}
+								maxTranslationLength={200}
 							/>
 						</div>
 


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
WordForm内の無駄なvalidationを削除。完全にTextPairManagerで同じようにバリデーションチェックをそれぞれ行うためにpropsでmaxを変更できるように

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1]WordForm内の無駄なコードの削除
- [変更点2]TextPairManagerで最大文字数のvalidationがpropsで管理できるように

## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [ ] TextPairManagerのvalidationが効いているか？

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->

## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->


## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->

[![Image from Gyazo](https://i.gyazo.com/55ec15f95990c1a043113c147568938c.png)](https://gyazo.com/55ec15f95990c1a043113c147568938c)

## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - テキストと翻訳フィールドに、動的な最大文字数制限が適用されるようになり、入力内容に合わせた柔軟な検証が実現されました。
  - 同義語、反意語、共起、例文の管理が専用コンポーネントを通じて行われ、直感的な操作が可能になりました。

- **リファクタリング**
  - 入力フォームの検証ロジックが整理され、よりシンプルで使いやすい構造に改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->