### PR TITLE
🐞 Fix: WordFormに変更があった場合のみ更新できるように+ImageSettingのinputの表示バグの解消

### DIFF
--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -34,6 +34,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 					<Badge
 						className="absolute right-3 top-5 animate-fade cursor-pointer"
 						onClick={handleSearch} // Badgeのクリックで検索をトリガー
+						size="sm"
 					>
 						<span className="sm:hidden">click</span>
 						<span className="hidden sm:inline">Enter or click</span>

--- a/app/components/ui/input.tsx
+++ b/app/components/ui/input.tsx
@@ -32,8 +32,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 				/>
 				{search && props.value && handleSearch && (
 					<Badge
-						className="absolute right-3 top-5 animate-fade cursor-pointer"
-						onClick={handleSearch} // Badgeのクリックで検索をトリガー
+						className="absolute right-3 top-1/2 -translate-y-1/2 animate-fade cursor-pointer"
+						onClick={handleSearch}
 						size="sm"
 					>
 						<span className="sm:hidden">click</span>

--- a/app/features/cards/word/components/WordForm.tsx
+++ b/app/features/cards/word/components/WordForm.tsx
@@ -188,7 +188,7 @@ const WordForm = ({ wordDetail }: { wordDetail: WordDetail }) => {
 				variant="black"
 				type="submit"
 				onClick={form.handleSubmit(onSubmit)}
-				disabled={!form.formState.isValid}
+				disabled={!form.formState.isValid || !form.formState.isDirty}
 				className="mb-3 ml-auto block"
 			>
 				更新する


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
ImageSettingのinput内のbadgeの表示バグの修正
WordFormの更新時のみ更新ボタンを押せるようにした。

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1] inputの表示が正しくできてるか？
- [変更点2]wordFormの値が変化した時のみdisabledが打てるか？


## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [ ] inputのbadge表示が正しくできてるか？
- [ ] wordform更新時のみ更新ボタンのdisabledが機能するか？


## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->


## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->


## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->

[![Image from Gyazo](https://i.gyazo.com/3525b4bb61c5e16c7721b017d0458712.png)](https://gyazo.com/3525b4bb61c5e16c7721b017d0458712)

## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 入力フィールド内の検索用アイコンの位置が中央に調整され、適切な小サイズで表示されるようになりました。
- **Bug Fixes**
  - 単語入力フォームの送信ボタンが、入力内容が未編集の場合にも無効となる条件が追加され、誤操作を防ぐ改善が行われました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->