### PR TITLE
💾 Change: kVのキャッシュからWorkersのCache APIに切り替える

### DIFF
--- a/app/components/global/Speech.tsx
+++ b/app/components/global/Speech.tsx
@@ -10,12 +10,14 @@ interface SpeechProps {
 const Speech = ({ word, size }: SpeechProps) => {
 	const { isPlaying, fetchAudio } = useAudio();
 
+	const speaker = "en-US-Standard-B";
+
 	const handlePlay = () => {
 		if (!word || word.trim() === "") {
 			alert("再生する単語がありません");
 			return;
 		}
-		fetchAudio(word);
+		fetchAudio(word, speaker);
 	};
 
 	return (

--- a/app/hooks/useAudio.ts
+++ b/app/hooks/useAudio.ts
@@ -6,7 +6,7 @@ export const useAudio = () => {
 	const { playAudio } = audioPlayer();
 
 	const fetchAudio = useCallback(
-		async (text: string) => {
+		async (text: string, speaker: string) => {
 			try {
 				setIsPlaying(true);
 
@@ -15,7 +15,7 @@ export const useAudio = () => {
 					headers: {
 						"Content-Type": "application/json",
 					},
-					body: JSON.stringify({ text }),
+					body: JSON.stringify({ text, speaker }),
 				});
 
 				if (!response.ok) {

--- a/binding.d.ts
+++ b/binding.d.ts
@@ -1,5 +1,0 @@
-export {};
-
-declare global {
-	const AUDIO_CACHE: KVNamespace;
-}

--- a/functions/api/audio.ts
+++ b/functions/api/audio.ts
@@ -1,28 +1,22 @@
 export async function onRequest(context: {
 	request: Request;
-	env: { GC_API_KEY: string; AUDIO_CACHE: KVNamespace };
+	env: { GC_API_KEY: string };
 }) {
 	try {
-		const requestData: { text: string } = await context.request.json();
-		const { text } = requestData;
+		const requestData: { text: string; speaker: string } =
+			await context.request.json();
+		const { text, speaker } = requestData;
 
-		const cacheKey = `audio_${encodeURIComponent(text.trim())}`;
-		const cachedAudio = await context.env.AUDIO_CACHE.get(
-			cacheKey,
-			"arrayBuffer",
+		const cache = await caches.open("default");
+		const cacheKey = new Request(
+			`${context.request.url}?text=${encodeURIComponent(text.trim())}&speaker=${encodeURIComponent(speaker)}`,
 		);
+		const cachedResponse = await cache.match(cacheKey);
 
-		if (cachedAudio) {
-			// キャッシュが存在する場合
-			return new Response(cachedAudio, {
-				status: 200,
-				headers: {
-					"Content-Type": "audio/wav",
-				},
-			});
+		if (cachedResponse) {
+			return cachedResponse;
 		}
 
-		// キャッシュが存在しない場合、音声データを生成
 		const response = await fetch(
 			`https://texttospeech.googleapis.com/v1/text:synthesize?key=${context.env.GC_API_KEY}`,
 			{
@@ -32,8 +26,7 @@ export async function onRequest(context: {
 					input: { text },
 					voice: {
 						languageCode: "en-US",
-						name: "en-US-Standard-F",
-						ssmlGender: "NEUTRAL",
+						name: speaker,
 					},
 					audioConfig: { audioEncoding: "LINEAR16" },
 				}),
@@ -48,18 +41,17 @@ export async function onRequest(context: {
 		}
 
 		const audioBuffer = await response.arrayBuffer();
-
-		// 生成した音声データをキャッシュに保存（TTLを設定して自動削除）
-		await context.env.AUDIO_CACHE.put(cacheKey, audioBuffer, {
-			expirationTtl: 86400,
-		}); // 24時間（86400秒）
-
-		return new Response(audioBuffer, {
+		const newResponse = new Response(audioBuffer, {
 			status: 200,
 			headers: {
 				"Content-Type": "audio/wav",
+				"Cache-Control": "public, max-age=86400",
 			},
 		});
+
+		await cache.put(cacheKey, newResponse.clone());
+
+		return newResponse;
 	} catch (error) {
 		console.error("Error:", error);
 		const statusCode =


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
KVはグローバルな公開データを見せるときに効果がある。今回のような一時的な音声データのキャッシュはworkersのCache APIで十分だと思ったので変更した。

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1]キャッシュ方法をKVからWorkersのCache APIにする
- [変更点2]speakerをリクエストに渡して、将来的にユーザーが選択したスピーカーを選べるように


## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [x] キャッシュが効いているか？

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->


## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->
- [CloudFlare KV](https://developers.cloudflare.com/kv/get-started/)
- [workersのCaChe API](https://developers.cloudflare.com/workers/runtime-apis/cache/)
- [text to speechの料金表](https://cloud.google.com/text-to-speech/pricing?hl=ja)

## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->
![スクリーンショットの説明](リンク)

## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->
将来的なjotaiからspeackerの値を取ってきてSpeech内で流すという形になる


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 音声出力処理に、選択可能な話者のパラメーターが追加され、より多様な音声体験が実現されました。
	- キャッシュ戦略の改良により、音声応答の取得が効率化され、レスポンス速度が向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->