### PR TITLE
✨ Feat: 設定画面でnoteの出力内容を設定できる機能を追加

### DIFF
--- a/app/features/settings/components/NotePrompt.tsx
+++ b/app/features/settings/components/NotePrompt.tsx
@@ -9,9 +9,9 @@ interface NotePromptProps {
 	note_prompt: string;
 }
 
-const NotePrompt = ({ note_prompt: initialName }: NotePromptProps) => {
+const NotePrompt = ({ note_prompt: initialPrompt }: NotePromptProps) => {
 	const [isEditing, setIsEditing] = useState(false);
-	const [displayName, setDisplayName] = useState(initialName);
+	const [displayPrompt, setDisplayPrompt] = useState(initialPrompt);
 	const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
 	useEffect(() => {
@@ -27,12 +27,12 @@ const NotePrompt = ({ note_prompt: initialName }: NotePromptProps) => {
 		setValue,
 	} = useForm<{ note_prompt: string }>({
 		resolver: zodResolver(NotePromptSchema),
-		defaultValues: { note_prompt: displayName },
+		defaultValues: { note_prompt: displayPrompt },
 	});
 
 	const onSubmit = (data: { note_prompt: string }) => {
 		console.log("保存するデータ:", data);
-		setDisplayName(data.note_prompt);
+		setDisplayPrompt(data.note_prompt);
 		setIsEditing(false);
 	};
 
@@ -72,17 +72,17 @@ const NotePrompt = ({ note_prompt: initialName }: NotePromptProps) => {
 								type="button"
 								onClick={() => {
 									setIsEditing(false);
-									setValue("note_prompt", displayName);
+									setValue("note_prompt", displayPrompt);
 								}}
 								className="text-gray-400 hover:text-gray-500"
-								aria-label="名前の編集をキャンセル"
+								aria-label="プロンプトの編集をキャンセル"
 							>
 								キャンセル
 							</Button>
 							<Button
 								variant="default"
 								type="submit"
-								aria-label="変更した名前を保存"
+								aria-label="変更したプロンプトを保存"
 							>
 								保存する
 							</Button>
@@ -90,10 +90,10 @@ const NotePrompt = ({ note_prompt: initialName }: NotePromptProps) => {
 					</form>
 				) : (
 					<>
-						<p className="text-gray-500">
+						<p className="text-gray-500 mt-2">
 							英単語作成時に、AIが生成する学習ノート内の表示形式をあなた自身がカスタマイズできます。例文や語源情報など、AIに作成させたい情報を自由に設定できます。
 						</p>
-						<Button variant="outline" onClick={startEditing}>
+						<Button variant="outline" onClick={startEditing} className="mt-4">
 							変更する
 						</Button>
 					</>

--- a/app/features/settings/components/NotePrompt.tsx
+++ b/app/features/settings/components/NotePrompt.tsx
@@ -1,0 +1,106 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import { Button } from "~/components/ui/button";
+import { Textarea } from "~/components/ui/textarea";
+import { NotePromptSchema } from "../schema/note_prompt";
+
+interface NotePromptProps {
+	note_prompt: string;
+}
+
+const NotePrompt = ({ note_prompt: initialName }: NotePromptProps) => {
+	const [isEditing, setIsEditing] = useState(false);
+	const [displayName, setDisplayName] = useState(initialName);
+	const inputRef = useRef<HTMLTextAreaElement | null>(null);
+
+	useEffect(() => {
+		if (isEditing) {
+			inputRef.current?.focus();
+		}
+	}, [isEditing]);
+
+	const {
+		register,
+		handleSubmit,
+		formState: { errors },
+		setValue,
+	} = useForm<{ note_prompt: string }>({
+		resolver: zodResolver(NotePromptSchema),
+		defaultValues: { note_prompt: displayName },
+	});
+
+	const onSubmit = (data: { note_prompt: string }) => {
+		console.log("保存するデータ:", data);
+		setDisplayName(data.note_prompt);
+		setIsEditing(false);
+	};
+
+	const startEditing = () => {
+		setIsEditing(true);
+	};
+
+	const { ref, ...registerRest } = register("note_prompt");
+
+	return (
+		<div className="rounded-lg border border-gray-200 p-6">
+			<div className="space-y-4">
+				<h2 className="text-base font-medium">ノートのカスタマイズ</h2>
+				{isEditing ? (
+					<form onSubmit={handleSubmit(onSubmit)} className="mt-5">
+						<div className="w-full">
+							<Textarea
+								placeholder="ノートに出力する内容を設定する"
+								{...registerRest}
+								ref={(element) => {
+									ref(element);
+									if (element) {
+										inputRef.current = element;
+									}
+								}}
+								className="border rounded-lg py-2.5 px-3 w-full"
+							/>
+							{errors.note_prompt && (
+								<p className="text-red-500 text-sm mt-1">
+									{errors.note_prompt.message?.toString()}
+								</p>
+							)}
+						</div>
+						<div className="mt-6 flex justify-end gap-2">
+							<Button
+								variant="ghost"
+								type="button"
+								onClick={() => {
+									setIsEditing(false);
+									setValue("note_prompt", displayName);
+								}}
+								className="text-gray-400 hover:text-gray-500"
+								aria-label="名前の編集をキャンセル"
+							>
+								キャンセル
+							</Button>
+							<Button
+								variant="default"
+								type="submit"
+								aria-label="変更した名前を保存"
+							>
+								保存する
+							</Button>
+						</div>
+					</form>
+				) : (
+					<>
+						<p className="text-gray-500">
+							英単語作成時に、AIが生成する学習ノート内の表示形式をあなた自身がカスタマイズできます。例文や語源情報など、AIに作成させたい情報を自由に設定できます。
+						</p>
+						<Button variant="outline" onClick={startEditing}>
+							変更する
+						</Button>
+					</>
+				)}
+			</div>
+		</div>
+	);
+};
+
+export default NotePrompt;

--- a/app/features/settings/index.tsx
+++ b/app/features/settings/index.tsx
@@ -1,4 +1,5 @@
 import DeleteAccount from "./components/DeleteAccount";
+import NotePrompt from "./components/NotePrompt";
 import ProfileImageSection from "./components/ProfileImageSetting";
 import ProfileNameSetting from "./components/ProfileNameSetting";
 import SpeakerSetting from "./components/SpeakerSetting";
@@ -12,6 +13,8 @@ const SettingsPage = () => {
 		name: "てる太郎",
 		speaker: "en-US-Standard-C" as SpeakerId,
 		cardCount: 6,
+		note_prompt:
+			"以下の英単語を使用して、日常生活で使える例文を3つ作成してください。各例文には、単語の意味と使い方の説明を含めてください。対象読者は英語学習初心者です。",
 	};
 
 	return (
@@ -26,6 +29,8 @@ const SettingsPage = () => {
 				<TrashSection cardCount={userData.cardCount} />
 
 				<TagSection />
+
+				<NotePrompt note_prompt={userData.note_prompt} />
 
 				<DeleteAccount />
 			</main>

--- a/app/features/settings/schema/note_prompt.ts
+++ b/app/features/settings/schema/note_prompt.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const NotePromptSchema = z.object({
+	note_prompt: z.string().max(500, "500文字以内で入力してください"),
+});


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
ノートという項目がAIで出力する内容がユーザーが調整できるように設定画面でFormを設けた

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1]/settngs画面の項目が機能してるか
- [変更点2]
- [変更点3]

## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [ ] /settings画面のノートのカスタマイズが機能しているか？

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->


## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->

## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->


## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 設定画面にノートプロンプトの編集機能を追加しました。ノートプロンプトは最大500文字まで入力可能で、編集・保存・キャンセルができます。
  - 入力内容にバリデーションが追加され、エラー時にはメッセージが表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->