### PR TITLE
🎨 Style: 全画面モードの際にスライドのみが強調表示されるように。

### DIFF
--- a/app/features/slide/components/SlideControls.tsx
+++ b/app/features/slide/components/SlideControls.tsx
@@ -7,7 +7,6 @@ import {
 	Minimize2,
 	Pause,
 	Play,
-	Shuffle,
 } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import {
@@ -33,7 +32,6 @@ interface SlideControlsProps {
 	toggleImages: () => void;
 	isLooping: boolean;
 	toggleLoop: () => void;
-	handleShuffle: () => void;
 	isSizing: boolean;
 	toggleSizing: () => void;
 }
@@ -47,7 +45,6 @@ export const SlideControls = ({
 	toggleImages,
 	isLooping,
 	toggleLoop,
-	handleShuffle,
 	isSizing,
 	toggleSizing,
 }: SlideControlsProps) => {
@@ -78,67 +75,60 @@ export const SlideControls = ({
 				</Tooltip>
 			</TooltipProvider>
 
-			<DropdownMenu>
-				<DropdownMenuTrigger asChild>
-					<Button size="icon">
-						<Hourglass />
-					</Button>
-				</DropdownMenuTrigger>
-				<DropdownMenuContent className="w-72">
-					<DropdownMenuLabel>
-						スライド1枚あたりの表示時間を設定
-					</DropdownMenuLabel>
-					<PlaybackSpeedControl
-						playbackSpeed={playbackSpeed}
-						setPlaybackSpeed={setPlaybackSpeed}
-					/>
-				</DropdownMenuContent>
-			</DropdownMenu>
+			{!isSizing && (
+				<>
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button size="icon">
+								<Hourglass />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent className="w-72">
+							<DropdownMenuLabel>
+								スライド1枚あたりの表示時間を設定
+							</DropdownMenuLabel>
+							<PlaybackSpeedControl
+								playbackSpeed={playbackSpeed}
+								setPlaybackSpeed={setPlaybackSpeed}
+							/>
+						</DropdownMenuContent>
+					</DropdownMenu>
 
-			<TooltipProvider>
-				<Tooltip>
-					<TooltipTriggerNoButton>
-						<Button
-							size="icon"
-							variant={showImages ? "black" : "default"}
-							onClick={toggleImages}
-						>
-							{showImages ? <Image /> : <ImageOff />}
-						</Button>
-					</TooltipTriggerNoButton>
-					<TooltipContent side="bottom">
-						{showImages ? "画像表示" : "画像非表示"}
-					</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTriggerNoButton>
+								<Button
+									size="icon"
+									variant={showImages ? "black" : "default"}
+									onClick={toggleImages}
+								>
+									{showImages ? <Image /> : <ImageOff />}
+								</Button>
+							</TooltipTriggerNoButton>
+							<TooltipContent side="bottom">
+								{showImages ? "画像表示" : "画像非表示"}
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
 
-			<TooltipProvider>
-				<Tooltip>
-					<TooltipTriggerNoButton>
-						<Button
-							size="icon"
-							variant={isLooping ? "black" : "default"}
-							onClick={toggleLoop}
-						>
-							<InfinityIcon />
-						</Button>
-					</TooltipTriggerNoButton>
-					<TooltipContent side="bottom">
-						ループ: {isLooping ? "オン" : "オフ"}
-					</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
-
-			<TooltipProvider>
-				<Tooltip>
-					<TooltipTriggerNoButton>
-						<Button size="icon" onClick={handleShuffle}>
-							<Shuffle />
-						</Button>
-					</TooltipTriggerNoButton>
-					<TooltipContent side="bottom">スライドをシャッフル</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTriggerNoButton>
+								<Button
+									size="icon"
+									variant={isLooping ? "black" : "default"}
+									onClick={toggleLoop}
+								>
+									<InfinityIcon />
+								</Button>
+							</TooltipTriggerNoButton>
+							<TooltipContent side="bottom">
+								ループ: {isLooping ? "オン" : "オフ"}
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				</>
+			)}
 
 			<TooltipProvider>
 				<Tooltip>

--- a/app/features/slide/components/WordsSlide.tsx
+++ b/app/features/slide/components/WordsSlide.tsx
@@ -31,7 +31,6 @@ const WordsSlide = ({
 		toggleLoop,
 		toggleImages,
 		setPlaybackSpeed,
-		handleShuffle,
 		handleSlideTouch,
 	} = useSlideState(data);
 
@@ -55,8 +54,10 @@ const WordsSlide = ({
 	}
 
 	return (
-		<div className="flex flex-col justify-center items-center">
-			<div className={isSizing ? "w-10/12" : "w-9/12"}>
+		<div
+			className={`flex flex-col justify-center items-center ${isSizing ? "w-full h-screen fixed top-0 left-0 z-50 bg-background" : ""}`}
+		>
+			<div className="w-9/12">
 				<Carousel
 					opts={{ loop: slide.isLooping }}
 					plugins={plugins}
@@ -92,7 +93,6 @@ const WordsSlide = ({
 					toggleImages={toggleImages}
 					isLooping={slide.isLooping}
 					toggleLoop={toggleLoop}
-					handleShuffle={handleShuffle}
 					isSizing={isSizing}
 					toggleSizing={toggleSizing}
 				/>

--- a/app/features/slide/hooks/useSlideState.ts
+++ b/app/features/slide/hooks/useSlideState.ts
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import type { SlideWord } from "../types";
-import { shuffleSlides } from "../utils/shuffle";
 
 interface SlideState {
 	isPlaying: boolean;
@@ -16,7 +15,6 @@ interface UseSlideStateReturn {
 	toggleLoop: () => void;
 	toggleImages: () => void;
 	setPlaybackSpeed: (speed: number) => void;
-	handleShuffle: () => void;
 	handleSlideTouch: () => void;
 }
 
@@ -47,13 +45,6 @@ export const useSlideState = (
 		setSlide((prev) => ({ ...prev, playbackSpeed: speed }));
 	};
 
-	const handleShuffle = () => {
-		setSlide((prev) => ({
-			...prev,
-			data: shuffleSlides(prev.data),
-		}));
-	};
-
 	const handleSlideTouch = () => {
 		setSlide((prev) => ({ ...prev, isPlaying: false }));
 	};
@@ -64,7 +55,6 @@ export const useSlideState = (
 		toggleLoop,
 		toggleImages,
 		setPlaybackSpeed,
-		handleShuffle,
 		handleSlideTouch,
 	};
 };


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
全画面表示の際にスライドのみが強調されるようにする。
シャッフルボタンが必要なくなったので、それに関する機能を削除。

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1]isSizingによるスライドの大きさ変更をやめて、スライドを真ん中に位置指定することでスライドのみを集中できるようにする
- [変更点2]ボタンがたくさんあることで表示崩れが起きていたので、不要だったシャッフルアイコンを削除


## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [ ] 拡大縮小がうまく機能しているか

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->
- Close #116 

## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->


## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->

[![Image from Gyazo](https://i.gyazo.com/e63ad4878e3796cc3d573b342afbfedb.png)](https://gyazo.com/e63ad4878e3796cc3d573b342afbfedb)

## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能の削除**
  - スライドコントロールからシャッフル（並び替え）ボタンを削除しました。

- **スタイル**
  - サイズ変更モード時のレイアウトと背景スタイルを調整しました。
  - スライド表示エリアの幅が常に一定（w-9/12）となりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->